### PR TITLE
Fix a bug where script does not work for main shops

### DIFF
--- a/searchhelper.user.js
+++ b/searchhelper.user.js
@@ -199,7 +199,7 @@ br = "<br>";
 hr = "<hr>";
 
 // Main Shops
-if(document.URL.indexOf("objects.phtml?type=shop") != -1) {
+if(document.URL.indexOf("objects.phtml?") != -1 && document.URL.indexOf("type=shop") != -1) {
     $("img[src*='/items/']").parent().parent().find("b").each(function(k,v) {
         $(v).after(makelinks($(v).text()) + br);
     });


### PR DESCRIPTION
The script will now load on main shops when the url is in `/objects.phtml?obj_type=98&type=shop` format. (It would only work for urls in `/objects.phtml?type=shop&obj_type=98` before)